### PR TITLE
Improve selection of Python versions

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -6,27 +6,26 @@ on:
       - py-*
 
 jobs:
-  Publish:
+  Unix:
     strategy:
       matrix:
-        os: [ubuntu-latest, macos-latest, windows-latest]
+        os: [ubuntu-latest, macos-latest]
         python: [3.7, 3.8, 3.9]
 
     runs-on: ${{ matrix.os }}
-
     environment: "Publish wheels"
 
     steps:
       - uses: actions/checkout@v2
-      - uses: actions/setup-python@v2
-        with:
-          python-version: ${{ matrix.python }}
-          architecture: x64
       - uses: actions-rs/toolchain@v1
         with:
           profile: minimal
           toolchain: stable
           override: true
+      - uses: actions/setup-python@v2
+        with:
+          python-version: ${{ matrix.python }}
+          architecture: x64
       - name: Publish
         uses: messense/maturin-action@v1
         with:
@@ -34,5 +33,25 @@ jobs:
           args: -m instant-segment-py/Cargo.toml
                 --no-sdist
                 --username __token__
-                --password ${{ secrets.MATURIN_PASSWORD }}
-                --interpreter $(python${{ matrix.python }} -V 2>&1 | cut -d ' ' -f 2)
+                --password ${{ secrets.PYPI_TOKEN }}
+                --interpreter python${{ matrix.python }}
+
+  Windows:
+    runs-on: windows-latest
+    environment: "Publish wheels"
+
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions-rs/toolchain@v1
+        with:
+          profile: minimal
+          toolchain: stable
+          override: true
+      - name: Publish all versions
+        uses: messense/maturin-action@v1
+        with:
+          command: publish
+          args: -m instant-segment-py/Cargo.toml
+                --no-sdist
+                --username __token__
+                --password ${{ secrets.PYPI_TOKEN }}


### PR DESCRIPTION
Publishing wheels wasn't working correctly before. Tested again against test.pypi.org and ultimately arrived at this solution where we explicitly install the desired version on Unix platforms and use maturin's autodiscovery to discover all the installed versions on Windows. On Windows, the `--interpreter` option doesn't appear to work (well), and autodiscovery finds all the installed versions anyway so that seems acceptable.